### PR TITLE
Rewrite in clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,236 @@
 version = 3
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "3.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "punch"
 version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = {version = "3.2.14", features = ["derive"]}

--- a/src/in_directory.rs
+++ b/src/in_directory.rs
@@ -1,29 +1,29 @@
 use std::fs;
 
+use crate::Args;
 
-
-pub fn create_in_dir(args: &Vec<String>){
-    for i in 3..args.len(){
-        if args[i].contains("/"){
-            fs::create_dir_all(format!("{}{}",args[2], args[i]))
-            .expect(format!("error creating folder: {}", args[i]).as_str());
-        }
-        else{
-            fs::File::create(format!("{}/{}",args[2], args[i]))
-            .expect(format!("error creating file: {}", args[i]).as_str());
+pub fn create_in_dir(args: &Args) {
+    let args = args.r#in.clone().unwrap();
+    for i in 0..args.len() {
+        if args[i].contains("/") {
+            fs::create_dir_all(format!("{}{}", args[2], args[i]))
+                .expect(format!("error creating folder: {}", args[i]).as_str());
+        } else {
+            fs::File::create(format!("{}/{}", args[2], args[i]))
+                .expect(format!("error creating file: {}", args[i]).as_str());
         }
     }
 }
 
-pub fn delete_files_dir(args: &Vec<String>){
-    for i in 3..args.len(){
-        if args[i].contains("/"){
-            fs::remove_dir_all(format!("{}{}",args[2], args[i]))
-            .expect(format!("error creating folder: {}", args[i]).as_str());
-        }
-        else{
-            fs::remove_file(format!("{}/{}",args[2], args[i]))
-            .expect(format!("error creating folder: {}", args[i]).as_str());
+pub fn delete_files_dir(args: &Args) {
+    let args = args.din.clone().unwrap();
+    for i in 1..args.len() {
+        if args[i].contains("/") {
+            fs::remove_dir_all(format!("{}{}", args[2], args[i]))
+                .expect(format!("error creating folder: {}", args[i]).as_str());
+        } else {
+            fs::remove_file(format!("{}/{}", args[2], args[i]))
+                .expect(format!("error creating folder: {}", args[i]).as_str());
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod in_directory;
 pub struct Args {
     /// to create file
     #[clap(short, value_parser, multiple_values = true)]
-    target: Option<Vec<String>>,
+    files: Option<Vec<String>>,
     /// to create a single file
     #[clap(value_parser)]
     create: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ pub struct Args {
     /// to create file
     #[clap(short, value_parser, multiple_values = true)]
     target: Option<Vec<String>>,
+    /// to create a single file
+    #[clap(value_parser)]
+    create: Option<String>,
     /// to delete
     #[clap(short, long, value_parser)]
     del: Option<Vec<String>>,
@@ -20,7 +23,6 @@ pub struct Args {
     #[clap(long, value_parser, multiple_values = true)]
     din: Option<Vec<String>>,
 }
-
 
 impl Args {
     fn input_type(&self) -> InputType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,64 +1,87 @@
-use std::env;
 use std::fs;
 
+use clap::Parser;
+
 mod in_directory;
-fn help_message(){
-    println!("punch (optional)<flag> <file/location> \n
-    
-    punch -h 'to bring up help' \n
-    punch <file_name> 'to create file' \n
-    punch -dir ./<directory_name>/ 'create directory' \n
-    punch ./<directory_name>/ 'to use without -dir flag' \n
-    punch -d <file_name> 'or'  punch -d ./<directory_name>/ 'to delete' \n
-    punch -in ./<target_directory_name>/ <file or directory_name> 'creates files inside target directory' \n
-    punch -din ./<target_directory_name>/ <file or directory_name> 'deletes files inside target directory' \n
-    ")
+
+#[derive(Debug, Parser)]
+#[clap(trailing_var_arg = true)]
+pub struct Args {
+    /// to create file
+    #[clap(short, value_parser, multiple_values = true)]
+    target: Option<Vec<String>>,
+    /// to delete
+    #[clap(short, long, value_parser)]
+    del: Option<Vec<String>>,
+    /// creates files inside target directory
+    #[clap(short, long, value_parser, multiple_values = true)]
+    r#in: Option<Vec<String>>,
+    /// deletes files inside target directory
+    #[clap(long, value_parser, multiple_values = true)]
+    din: Option<Vec<String>>,
 }
 
-fn create_files(args: &Vec<String>){
-    for i in 1..args.len(){
-        if args[i].contains("/") && args[i].ends_with("/"){
-                fs::create_dir_all(&args[i])
+
+impl Args {
+    fn input_type(&self) -> InputType {
+        if let Some(_) = self.din {
+            return InputType::DeleteIn;
+        } else if let Some(_) = self.del {
+            return InputType::Del;
+        } else if let Some(_) = self.r#in {
+            return InputType::CreateIn;
+        } else if let Some(_) = self.target {
+            return InputType::Create;
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+#[derive(Debug)]
+enum InputType {
+    DeleteIn,
+    CreateIn,
+    Del,
+    Create,
+}
+
+fn create_files(args: &Args) {
+    let args = args.target.clone().unwrap();
+    for i in 0..args.len() {
+        if args[i].contains("/") && args[i].ends_with("/") {
+            fs::create_dir_all(&args[i])
                 .expect(format!("error creating folder: {}", args[i]).as_str());
-        }
-        else{
-            fs::File::create(&args[i])
-            .expect(format!("error creating file: {}", args[i]).as_str());
-
+        } else {
+            fs::File::create(&args[i]).expect(format!("error creating file: {}", args[i]).as_str());
         }
     }
 }
-fn delete_files(args: &Vec<String>){
-    for i in 2..args.len(){
-        if args[i].contains("/") && args[i].ends_with("/"){
+fn delete_files(args: &Args) {
+    let args = args.del.clone().unwrap();
+    for i in 0..args.len() {
+        if args[i].contains("/") && args[i].ends_with("/") {
             fs::remove_dir_all(&args[i])
-            .expect(format!("error deleting folder: {}", args[i]).as_str());
-        }
-        else{
-            fs::remove_file(&args[i])
-            .expect(format!("error deleting file: {}", args[i]).as_str());
+                .expect(format!("error deleting folder: {}", args[i]).as_str());
+        } else {
+            fs::remove_file(&args[i]).expect(format!("error deleting file: {}", args[i]).as_str());
         }
     }
 }
-fn create_directory(args: &Vec<String>){
-    for i in 2..args.len(){
-        fs::create_dir_all(&args[i])
-        .expect(format!("error creating folder: {}", args[i]).as_str());
+fn create_directory(args: &Args) {
+    let args = args.target.clone().unwrap();
+    for i in 0..args.len() {
+        fs::create_dir_all(&args[i]).expect(format!("error creating folder: {}", args[i]).as_str());
     }
 }
 
-fn main(){
-    let args: Vec<String> = env::args().collect();
-
-    match args[1].as_str(){
-       "-d"|"-delete" => delete_files(&args),
-       "-h"|"-help" => help_message(),
-       "-din" => in_directory::delete_files_dir(&args),
-       "-in" => in_directory::create_in_dir(&args),
-       "-dir" => create_directory(&args),
-       _ => create_files(&args)
+fn main() {
+    let args = Args::parse();
+    match args.input_type() {
+        InputType::DeleteIn => in_directory::delete_files_dir(&args),
+        InputType::CreateIn => in_directory::create_in_dir(&args),
+        InputType::Del => delete_files(&args),
+        InputType::Create => create_files(&args),
     }
-
-
-    
 }
+


### PR DESCRIPTION
To create multiple files you must now use `-f` as clap does not have optional positional infinite arguments.