### PR TITLE
FIX: running command with no args should not panic

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PunchError {
+    #[error("Invalid command given to CLI")]
+    CliInvalidInputError,
     #[error("Unable to create file {0}")]
     CreateFileError(String),
     #[error("Unable to create directory {0}")]


### PR DESCRIPTION
## Description

Running with no args results in a panic
This fix will print the error and also show the user how to use the CLI by printing help.

## More Info

Running with no args on master

```
➜  punch git:(master) cargo run
  Downloaded shellexpand v2.1.0
  Downloaded 1 crate (14.7 KB) in 0.44s
   Compiling dirs-sys-next v0.1.2
   Compiling dirs-next v2.0.0
   Compiling shellexpand v2.1.0
   Compiling punch v0.1.0 (/home/aburd/code/rust/punch)
    Finished dev [unoptimized + debuginfo] target(s) in 2.23s
     Running `target/debug/punch`
thread 'main' panicked at 'internal error: entered unreachable code', src/main.rs:73:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After fix
```
➜  punch git:(fix/bin-default) cargo run
   Compiling punch v0.1.0 (/home/aburd/code/rust/punch)
    Finished dev [unoptimized + debuginfo] target(s) in 1.38s
     Running `target/debug/punch`
Error: Invalid command given to CLI
punch 1.7.5

USAGE:
    punch [OPTIONS] [--] [TARGET]...

ARGS:
    <TARGET>...    To create file or directory

OPTIONS:
        --clear               Clears the trash Directory
    -d, --del <DEL>           To delete
        --din <DIN>...        Deletes files inside target directory-first arguement is target
    -h, --help                Print help information
    -i, --in <IN>...          Creates files inside target directory-first arguement is target
    -l, --list                Lists the files and directories in the current working directory
    -m, --mve <MVE>...        Move a file from one directory to another
    -o, --open <OPEN>...      Opens file with default application
    -r, --ren <REN>...        Renam a file
    -s, --show                Prints out creation,deletion, and trash history
    -t, --trash <TRASH>...    Sends the file to trash can
    -u, --undo                Undoes last create or trash
    -V, --version             Print version information

EXTRA:
        --db-delete <DB_DELETE>    deletes specific file name from database
        --sizeof <SIZEOF>...       returns size of file or directory
```